### PR TITLE
add table name customize option

### DIFF
--- a/lib/yacto/schema.ex
+++ b/lib/yacto/schema.ex
@@ -39,10 +39,17 @@ defmodule Yacto.Schema do
         case Application.fetch_env(:yacto, :table_name_converter) do
           :error -> __MODULE__ |> Macro.underscore() |> String.replace("/", "_")
           {:ok, {regex, replacement}} ->
-            __MODULE__
-            |> Macro.underscore()
-            |> String.replace("/", "_")
-            |> (fn s -> Regex.replace(Regex.compile!(regex), s, replacement) end).()
+            r = Regex.compile!(regex)
+            module_name =
+              __MODULE__
+              |> Macro.underscore()
+              |> String.replace("/", "_")
+
+              unless Regex.match?(r, module_name) do
+                raise MatchError, term: "module_name #{module_name} is unmatched pattern: #{inspect(r)}"
+              end
+
+            Regex.replace(r, module_name, replacement)
         end
       )
 

--- a/lib/yacto/schema.ex
+++ b/lib/yacto/schema.ex
@@ -35,7 +35,16 @@ defmodule Yacto.Schema do
     quote do
       @behaviour Yacto.Schema
 
-      @auto_source __MODULE__ |> Macro.underscore() |> String.replace("/", "_")
+      @auto_source (
+        case Application.fetch_env(:yacto, :table_name_converter) do
+          :error -> __MODULE__ |> Macro.underscore() |> String.replace("/", "_")
+          {:ok, {regex, replacement}} ->
+            __MODULE__
+            |> Macro.underscore()
+            |> String.replace("/", "_")
+            |> (fn s -> Regex.replace(Regex.compile!(regex), s, replacement) end).()
+        end
+      )
 
       import Yacto.Schema, only: [schema: 2]
 

--- a/test/apps/custom_table_name/config/config.exs
+++ b/test/apps/custom_table_name/config/config.exs
@@ -1,0 +1,26 @@
+use Mix.Config
+
+config :custom_table_name, :ecto_repos, [CustomTableName.Repo0, CustomTableName.Repo1]
+
+config :custom_table_name, CustomTableName.Repo0,
+  adapter: Ecto.Adapters.MySQL,
+  database: "custom_table_name_repo0",
+  username: "root",
+  password: "",
+  hostname: "localhost",
+  port: "3306"
+
+config :custom_table_name, CustomTableName.Repo1,
+  adapter: Ecto.Adapters.MySQL,
+  database: "custom_table_name_repo1",
+  username: "root",
+  password: "",
+  hostname: "localhost",
+  port: "3306"
+
+config :yacto, :databases, %{
+  default: %{module: Yacto.DB.Single, repo: CustomTableName.Repo1},
+  player: %{module: Yacto.DB.Shard, repos: [CustomTableName.Repo0, CustomTableName.Repo1]}
+}
+
+config :yacto, table_name_converter: {"^(.*)_schema(.*)_test_data", "\\1\\2"}

--- a/test/apps/custom_table_name/lib/custom_table_name.ex
+++ b/test/apps/custom_table_name/lib/custom_table_name.ex
@@ -8,13 +8,3 @@ defmodule CustomTableName.Player.Schema.TestData do
   end
 end
 
-defmodule CustomTableName.Player.Unmatch.TestData do
-  use Yacto.Schema
-
-  def dbname(), do: :player
-
-  schema @auto_source do
-    field(:name, :string, default: "hoge", meta: [null: false, size: 100])
-  end
-end
-

--- a/test/apps/custom_table_name/lib/custom_table_name.ex
+++ b/test/apps/custom_table_name/lib/custom_table_name.ex
@@ -4,23 +4,17 @@ defmodule CustomTableName.Player.Schema.TestData do
   def dbname(), do: :player
 
   schema @auto_source do
-    field(:name, :string, default: "hage", meta: [null: false, size: 100])
-    field(:value, :string)
-    field(:text, :string, source: :text_data, meta: [type: :text, null: false])
-    index([:value, :name])
-    index([:name, :value], unique: true)
+    field(:name, :string, default: "hoge", meta: [null: false, size: 100])
   end
 end
 
-defmodule CustomTableName.Item do
+defmodule CustomTableName.Player.Unmatch.TestData do
   use Yacto.Schema
 
-  def dbname(), do: :default
-
-  @primary_key {:id, :binary_id, autogenerate: true}
+  def dbname(), do: :player
 
   schema @auto_source do
-    field(:name, :string, meta: [null: false])
+    field(:name, :string, default: "hoge", meta: [null: false, size: 100])
   end
 end
 

--- a/test/apps/custom_table_name/lib/custom_table_name.ex
+++ b/test/apps/custom_table_name/lib/custom_table_name.ex
@@ -1,0 +1,26 @@
+defmodule CustomTableName.Player.Schema.TestData do
+  use Yacto.Schema
+
+  def dbname(), do: :player
+
+  schema @auto_source do
+    field(:name, :string, default: "hage", meta: [null: false, size: 100])
+    field(:value, :string)
+    field(:text, :string, source: :text_data, meta: [type: :text, null: false])
+    index([:value, :name])
+    index([:name, :value], unique: true)
+  end
+end
+
+defmodule CustomTableName.Item do
+  use Yacto.Schema
+
+  def dbname(), do: :default
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+
+  schema @auto_source do
+    field(:name, :string, meta: [null: false])
+  end
+end
+

--- a/test/apps/custom_table_name/mix.exs
+++ b/test/apps/custom_table_name/mix.exs
@@ -1,0 +1,29 @@
+defmodule CustomTableName.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :custom_table_name,
+      version: "0.1.0",
+      build_path: "../.build",
+      config_path: "config/config.exs",
+      deps_path: "../.deps",
+      lockfile: "../mix.lock",
+      elixir: "~> 1.5",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:yacto, path: "../../.."},
+      {:power_assert, "~> 0.1.1", only: :test}
+    ]
+  end
+end

--- a/test/apps/custom_table_name/test/custom_table_name_test.exs
+++ b/test/apps/custom_table_name/test/custom_table_name_test.exs
@@ -1,0 +1,44 @@
+defmodule CustomTableNameTest do
+  use PowerAssert
+
+  @migrate """
+  defmodule CustomTableName.Migration20170424155528 do
+    use Ecto.Migration
+
+    def change(CustomTableName.Player.Schema.TestData) do
+      create table("custom_table_name_player")
+      alter table("custom_table_name_player") do
+        add(:name, :string, [default: "hage", null: false, size: 100])
+        add(:text_data, :text, [null: false])
+        add(:value, :string, [])
+      end
+      create index("custom_table_name_player", [:name, :value], [name: "name_value_index", unique: true])
+      create index("custom_table_name_player", [:value, :name], [name: "value_name_index"])
+    end
+
+    def change(_other) do
+      :ok
+    end
+
+    def __migration_structures__() do
+      [
+        {CustomTableName.Player.Schema.TestData, %Yacto.Migration.Structure{field_sources: %{id: :id, name: :name, text: :text_data, value: :value}, fields: [:id, :name, :value, :text], meta: %{attrs: %{name: %{default: "hage", null: false, size: 100}, text: %{null: false}}, indices: %{{[:name, :value], [unique: true]} => true, {[:value, :name], []} => true}}, source: "custom_table_name_player", types: %{id: :id, name: :string, text: :text, value: :string}}},
+      ]
+    end
+
+    def __migration_version__() do
+      20170424155528
+    end
+  end
+  """
+
+  test "Yacto.Migration.GenMigration generate_source with custom table name." do
+    v1 = [
+      {CustomTableName.Player.Schema.TestData, %Yacto.Migration.Structure{},
+       Yacto.Migration.Structure.from_schema(CustomTableName.Player.Schema.TestData)}
+    ]
+
+    source = Yacto.Migration.GenMigration.generate_source(CustomTableName, v1, 20_170_424_155_528)
+    assert @migrate == source
+  end
+end

--- a/test/apps/custom_table_name/test/custom_table_name_test.exs
+++ b/test/apps/custom_table_name/test/custom_table_name_test.exs
@@ -8,12 +8,8 @@ defmodule CustomTableNameTest do
     def change(CustomTableName.Player.Schema.TestData) do
       create table("custom_table_name_player")
       alter table("custom_table_name_player") do
-        add(:name, :string, [default: "hage", null: false, size: 100])
-        add(:text_data, :text, [null: false])
-        add(:value, :string, [])
+        add(:name, :string, [default: "hoge", null: false, size: 100])
       end
-      create index("custom_table_name_player", [:name, :value], [name: "name_value_index", unique: true])
-      create index("custom_table_name_player", [:value, :name], [name: "value_name_index"])
     end
 
     def change(_other) do
@@ -22,7 +18,7 @@ defmodule CustomTableNameTest do
 
     def __migration_structures__() do
       [
-        {CustomTableName.Player.Schema.TestData, %Yacto.Migration.Structure{field_sources: %{id: :id, name: :name, text: :text_data, value: :value}, fields: [:id, :name, :value, :text], meta: %{attrs: %{name: %{default: "hage", null: false, size: 100}, text: %{null: false}}, indices: %{{[:name, :value], [unique: true]} => true, {[:value, :name], []} => true}}, source: "custom_table_name_player", types: %{id: :id, name: :string, text: :text, value: :string}}},
+        {CustomTableName.Player.Schema.TestData, %Yacto.Migration.Structure{field_sources: %{id: :id, name: :name}, fields: [:id, :name], meta: %{attrs: %{name: %{default: "hoge", null: false, size: 100}}, indices: %{}}, source: "custom_table_name_player", types: %{id: :id, name: :string}}},
       ]
     end
 

--- a/test/apps/custom_table_name/test/custom_table_name_test.exs
+++ b/test/apps/custom_table_name/test/custom_table_name_test.exs
@@ -37,4 +37,18 @@ defmodule CustomTableNameTest do
     source = Yacto.Migration.GenMigration.generate_source(CustomTableName, v1, 20_170_424_155_528)
     assert @migrate == source
   end
+
+  test "Yacto.Migration.GenMigration generate_source with unmatched regex." do
+    assert_raise MatchError, "no match of right hand side value: \"module_name custom_table_name_test_custom_table_name_player_unmatch_test_data is unmatched pattern: ~r/^(.*)_schema(.*)_test_data/\"", fn ->
+      defmodule CustomTableName.Player.Unmatch.TestData do
+        use Yacto.Schema
+      
+        def dbname(), do: :player
+      
+        schema @auto_source do
+          field(:name, :string, default: "hoge", meta: [null: false, size: 100])
+        end
+      end
+    end
+  end
 end

--- a/test/apps/custom_table_name/test/test_helper.exs
+++ b/test/apps/custom_table_name/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
### 概要
`yacto.gen.migration`で生成されるマイグレーションファイルのテーブル名が、モデルのmodule名から自動生成していました。
モジュールによっては少し長いので、自由にテーブル名を正規表現で変更できるようにしました。

### 内容

#### 使い方

下記のように `config`のオプションで`table_name_converter`にタプルを渡します。

```
config :yacto, table_name_converter: {"^(.*)_schema(.*)_test_data", "\\1\\2"}
```

タプルの内容は下記の通りになります。
* 第一要素が変換前のデータにかける正規表現
* 第二要素がそれを受けて変換する文字列

第一要素にマッチさせる変換対象の文字列は`ドットつなぎのアッパーキャメルケース`ではなく、`アンダースネークケース`のものになるので注意してください。

ex. `Yacto.Example.TestPlayer.Data` -> `yacto_example_test_player_data`

### その他
設定名やテストケースの不足などありましたらおっしゃってください。