### PR TITLE
テーブル名の命名規則を変更

### DIFF
--- a/lib/yacto/schema.ex
+++ b/lib/yacto/schema.ex
@@ -37,7 +37,10 @@ defmodule Yacto.Schema do
 
       @auto_source (case Application.fetch_env(:yacto, :table_name_converter) do
                       :error ->
-                        __MODULE__ |> Macro.underscore() |> String.replace("/", "_")
+                        __MODULE__
+                        |> Macro.underscore()
+                        |> String.replace("_", "")
+                        |> String.replace("/", "_")
 
                       {:ok, {regex, replacement}} ->
                         r = Regex.compile!(regex)
@@ -45,6 +48,7 @@ defmodule Yacto.Schema do
                         module_name =
                           __MODULE__
                           |> Macro.underscore()
+                          |> String.replace("_", "")
                           |> String.replace("/", "_")
 
                         unless Regex.match?(r, module_name) do

--- a/test/apps/custom_table_name/config/config.exs
+++ b/test/apps/custom_table_name/config/config.exs
@@ -23,4 +23,4 @@ config :yacto, :databases, %{
   player: %{module: Yacto.DB.Shard, repos: [CustomTableName.Repo0, CustomTableName.Repo1]}
 }
 
-config :yacto, table_name_converter: {"^(.*)_schema(.*)_test_data", "\\1\\2"}
+config :yacto, table_name_converter: {"^(.*)_schema(.*)_testdata", "\\1\\2"}

--- a/test/apps/custom_table_name/test/custom_table_name_test.exs
+++ b/test/apps/custom_table_name/test/custom_table_name_test.exs
@@ -6,8 +6,8 @@ defmodule CustomTableNameTest do
     use Ecto.Migration
 
     def change(CustomTableName.Player.Schema.TestData) do
-      create table("custom_table_name_player")
-      alter table("custom_table_name_player") do
+      create table("customtablename_player")
+      alter table("customtablename_player") do
         add(:name, :string, [default: "hoge", null: false, size: 100])
       end
     end
@@ -18,7 +18,7 @@ defmodule CustomTableNameTest do
 
     def __migration_structures__() do
       [
-        {CustomTableName.Player.Schema.TestData, %Yacto.Migration.Structure{field_sources: %{id: :id, name: :name}, fields: [:id, :name], meta: %{attrs: %{name: %{default: "hoge", null: false, size: 100}}, indices: %{}}, source: "custom_table_name_player", types: %{id: :id, name: :string}}},
+        {CustomTableName.Player.Schema.TestData, %Yacto.Migration.Structure{field_sources: %{id: :id, name: :name}, fields: [:id, :name], meta: %{attrs: %{name: %{default: "hoge", null: false, size: 100}}, indices: %{}}, source: "customtablename_player", types: %{id: :id, name: :string}}},
       ]
     end
 
@@ -41,8 +41,8 @@ defmodule CustomTableNameTest do
   test "Yacto.Migration.GenMigration generate_source with unmatched regex." do
     message =
       "no match of right hand side value: " <>
-        "\"module_name custom_table_name_test_custom_table_name_player_unmatch_test_data is unmatched pattern: " <>
-        "~r/^(.*)_schema(.*)_test_data/\""
+        "\"module_name customtablenametest_customtablename_player_unmatch_testdata is unmatched pattern: " <>
+        "~r/^(.*)_schema(.*)_testdata/\""
 
     assert_raise(
       MatchError,

--- a/test/apps/gen_migration/test/gen_migration_test.exs
+++ b/test/apps/gen_migration/test/gen_migration_test.exs
@@ -100,13 +100,13 @@ defmodule GenMigrationTest do
     use Ecto.Migration
 
     def change(GenMigration.Player) do
-      rename table("player2"), to: table("gen_migration_player3")
-      alter table("gen_migration_player3") do
+      rename table("player2"), to: table("genmigration_player3")
+      alter table("genmigration_player3") do
         remove(:name2)
         add(:name3, :string, [null: false, size: 100])
       end
-      create index("gen_migration_player3", [:name3, :value], [name: "name3_value_index", unique: true])
-      create index("gen_migration_player3", [:value, :name3], [name: "value_name3_index"])
+      create index("genmigration_player3", [:name3, :value], [name: "name3_value_index", unique: true])
+      create index("genmigration_player3", [:value, :name3], [name: "value_name3_index"])
     end
 
     def change(_other) do
@@ -115,7 +115,7 @@ defmodule GenMigrationTest do
 
     def __migration_structures__() do
       [
-        {GenMigration.Player, %Yacto.Migration.Structure{field_sources: %{id: :id, name3: :name3, value: :value}, fields: [:id, :name3, :value], meta: %{attrs: %{name3: %{null: false, size: 100}}, indices: %{{[:name3, :value], [unique: true]} => true, {[:value, :name3], []} => true}}, source: "gen_migration_player3", types: %{id: :id, name3: :string, value: :string}}},
+        {GenMigration.Player, %Yacto.Migration.Structure{field_sources: %{id: :id, name3: :name3, value: :value}, fields: [:id, :name3, :value], meta: %{attrs: %{name3: %{null: false, size: 100}}, indices: %{{[:name3, :value], [unique: true]} => true, {[:value, :name3], []} => true}}, source: "genmigration_player3", types: %{id: :id, name3: :string, value: :string}}},
       ]
     end
 
@@ -130,7 +130,7 @@ defmodule GenMigrationTest do
     use Ecto.Migration
 
     def change(GenMigration.Player) do
-      drop table("gen_migration_player3")
+      drop table("genmigration_player3")
     end
 
     def change(_other) do
@@ -185,12 +185,12 @@ defmodule GenMigrationTest do
     use Ecto.Migration
 
     def change(GenMigration.Item) do
-      create table("gen_migration_item")
-      alter table("gen_migration_item") do
+      create table("genmigration_item")
+      alter table("genmigration_item") do
         add(:_gen_migration_dummy, :integer, [])
         remove(:id)
       end
-      alter table("gen_migration_item") do
+      alter table("genmigration_item") do
         remove(:_gen_migration_dummy)
         add(:id, :binary_id, [primary_key: true, autogenerate: true])
         add(:name, :string, [])
@@ -203,7 +203,7 @@ defmodule GenMigrationTest do
 
     def __migration_structures__() do
       [
-        {GenMigration.Item, %Yacto.Migration.Structure{autogenerate_id: {:id, :id, :binary_id}, field_sources: %{id: :id, name: :name}, fields: [:id, :name], source: "gen_migration_item", types: %{id: :binary_id, name: :string}}},
+        {GenMigration.Item, %Yacto.Migration.Structure{autogenerate_id: {:id, :id, :binary_id}, field_sources: %{id: :id, name: :name}, fields: [:id, :name], source: "genmigration_item", types: %{id: :binary_id, name: :string}}},
       ]
     end
 

--- a/test/yacto/migration/schema_test.exs
+++ b/test/yacto/migration/schema_test.exs
@@ -13,7 +13,7 @@ defmodule Yacto.Migration.SchemaTest do
   end
 
   test "use EctoSchema" do
-    assert "yacto_migration_schema_test_schema" == Schema.__schema__(:source)
+    assert "yacto_migration_schematest_schema" == Schema.__schema__(:source)
   end
 
   defmodule TestMeta do

--- a/test/yacto/migration/structure_test.exs
+++ b/test/yacto/migration/structure_test.exs
@@ -19,10 +19,10 @@ defmodule Yacto.Migration.StructureTest do
   test "inspect" do
     structure = Yacto.Migration.Structure.from_schema(Schema)
 
-    assert "%Yacto.Migration.Structure{source: \"yacto_migration_structure_test_schema\"}" ==
+    assert "%Yacto.Migration.Structure{source: \"yacto_migration_structuretest_schema\"}" ==
              inspect(structure)
 
-    assert "%Yacto.Migration.Structure{source: \"yacto_migration_structure_test_schema\"}" ==
+    assert "%Yacto.Migration.Structure{source: \"yacto_migration_structuretest_schema\"}" ==
              Yacto.Migration.Structure.to_string(structure)
   end
 end


### PR DESCRIPTION
### 概要
テーブル名の命名規則がElixirのモジュール名のつなぎ目`.`とキャメルケースのつなぎ目の両方を`_`に変えていた部分を変更しました。

### 内容
キャメルケースのつなぎ目の`_`をなくして、一つの単語になるように修正しました。
```
before: Yacto.PlayerItem -> yacto_player_item
after: Yacto.PlayerItem -> yacto_palyeritem
```