### PR TITLE
Elixir 1.9.0 へアップデート

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.0-otp-21
-erlang 21.1.1
+elixir 1.9.0-otp-22
+erlang 22.0.5

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # config for testing
 

--- a/lib/yacto/migration/util.ex
+++ b/lib/yacto/migration/util.ex
@@ -224,7 +224,7 @@ defmodule Yacto.Migration.Util do
         throw({:error, [message]})
       end
 
-      if Map.size(referenced_migrations) != 0 && length(root) == 0 do
+      if map_size(referenced_migrations) != 0 && length(root) == 0 do
         throw({:error, ["マイグレーションファイルの指定が循環しています。"]})
       end
 


### PR DESCRIPTION
* 利用している Elixirのバージョンを1.9.0, OTPのバージョンを22へアップデートしました。
* Map.size/2 がdeprecatedになったので、Kernel.map_size/2 を使うように修正しました。
* Mix.Config がdeprecatedになったので、代わりにConfigを使うように修正しました。