### PR TITLE
feature/enable optional migration

### DIFF
--- a/lib/mix/tasks/yacto.gen.migration.ex
+++ b/lib/mix/tasks/yacto.gen.migration.ex
@@ -16,6 +16,8 @@ defmodule Mix.Tasks.Yacto.Gen.Migration do
 
         _ = Application.load(app)
         schemas = Yacto.Migration.Util.get_all_schema(app)
+                  |> Enum.filter(fn schema ->
+                     Yacto.Migration.Util.need_gen_migration?(schema) end)
 
         validated =
           Yacto.Migration.Util.get_migration_files(app)

--- a/lib/yacto/migration/util.ex
+++ b/lib/yacto/migration/util.ex
@@ -95,6 +95,13 @@ defmodule Yacto.Migration.Util do
     end)
   end
 
+  def need_gen_migration?(schema) do
+    case function_exported?(schema, :gen_migration?, 0) do
+      true -> schema.gen_migration?
+      false -> true
+    end
+  end
+
   def is_migration_module?(mod), do: function_exported?(mod, :__migration__, 0)
 
   def load_migrations(migration_files) do

--- a/lib/yacto/schema.ex
+++ b/lib/yacto/schema.ex
@@ -27,6 +27,7 @@ defmodule Yacto.Schema do
 
   defmacro __using__(opts) do
     dbname = Keyword.get(opts, :dbname)
+    migration = Keyword.get(opts, :migration, true)
 
     quote do
       @behaviour Yacto.Schema
@@ -69,6 +70,10 @@ defmodule Yacto.Schema do
       @yacto_attrs %{}
       @yacto_indices %{}
       @yacto_types %{}
+
+      def gen_migration? do
+        unquote(migration)
+      end
 
       if unquote(dbname) != nil do
         @impl Yacto.Schema


### PR DESCRIPTION
# WHAT
migrationファイルの生成をオプショナルにしました。
migration: false というオプションをつけることでmigrationファイルを生成しないようにしています。

### 例
```
defmodule Sample.Models.Item do
  use Yacto.Schema dbname: :default, migration: false
end
```

※migrationオプションのdefault値はtrueです。

# WHY
migrationを生成しないORMを定義することで
PhoenixにおけるEctoのようにコンテキストごとに振る舞いの異なるModelを定義・使用したいという意図です。
